### PR TITLE
PROD-54/feature: translation metabox

### DIFF
--- a/src/TranslationMetaBox.php
+++ b/src/TranslationMetaBox.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace WpContentTranslate;
+
+/**
+ * Class PostMetaBox
+ *
+ * @package \Bonnier\WP\Cache\Admin
+ */
+class TranslationMetaBox
+{
+    const TRANSLATION_STATE = 'translation_state';
+    const TRANSLATION_DEADLINE = 'translation_deadline';
+
+    public static function register()
+    {
+        add_action('do_meta_boxes', function () {
+            add_meta_box(
+                'wp_content_translate',
+                'Translation State',
+                [__CLASS__, 'metaBoxContent'],
+                collect(get_post_types(['public' => true]))->reject('attachment')->toArray(),
+                'side'
+            );
+        });
+        add_action('save_post', [__CLASS__, 'saveMetaBoxSettings']);
+    }
+
+    public static function metaBoxContent($post)
+    {
+        static::printTranslationState($post);
+        static::printTranslationDeadline($post);
+    }
+
+    public static function saveMetaBoxSettings($postId)
+    {
+        if (isset($_POST[static::TRANSLATION_STATE])) {
+            update_post_meta($postId, static::TRANSLATION_STATE, $_POST[static::TRANSLATION_STATE]);
+        }
+        if (isset($_POST[static::TRANSLATION_DEADLINE])) {
+            $formattedDate = date('Ymd', strtotime($_POST[static::TRANSLATION_DEADLINE]));
+            update_post_meta($postId,static::TRANSLATION_DEADLINE, $formattedDate);
+        }
+    }
+
+    private static function printTranslationState($post)
+    {
+        $translationStates = [
+            'Ready for translation' => 'ready',
+            'In progress'           => 'progress',
+            'Translated'            => 'translated',
+        ];
+
+        $postTranslationState = get_post_meta($post->ID, static::TRANSLATION_STATE, true);
+
+        echo
+            sprintf(
+                '<p><strong>Translation Status</strong></p><select name="%s"><option value="" %s>- Select -</option>',
+                static::TRANSLATION_STATE,
+                $postTranslationState ? 'selected="selected"' : ''
+            )
+            .
+            collect($translationStates)->map(function ($translationState, $label) use ($postTranslationState) {
+                return sprintf(
+                    '<option value="%s" %s>%s</option>',
+                    $translationState,
+                    $postTranslationState === $translationState ? 'selected="selected"' : '',
+                    $label
+                );
+            })->implode('')
+            .
+            '</select><br>';
+    }
+
+    private static function printTranslationDeadline($post)
+    {
+        echo '<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+             <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>';
+
+        echo sprintf(
+            '<p><strong>Translation Deadline</strong></p><input type="text" id="%s" name="%s" value="%s">',
+            static::TRANSLATION_DEADLINE,
+            static::TRANSLATION_DEADLINE,
+            get_post_meta($post->ID, static::TRANSLATION_DEADLINE, true) ?: ''
+        );
+
+        echo sprintf(
+            '<script type="text/javascript"> flatpickr("#%s", { dateFormat: "M d, Y" }); </script>',
+            static::TRANSLATION_DEADLINE
+        );
+    }
+}

--- a/wp-content-translate.php
+++ b/wp-content-translate.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: WP Content Translate
- * Version: 1.1.0
+ * Version: 2.0.0
  * Plugin URI: https://github.com/BenjaminMedia/wp-translate
  * Description: Mark translation ready content with this smart plugin!
  * Author: Bonnier - Michael Sørensen
@@ -96,6 +96,7 @@ class Plugin
     {
         $columns = new Columns();
         $columns->registerColumns();
+        TranslationMetaBox::register();
     }
 
     private function bootstrap()
@@ -122,26 +123,20 @@ function translation_deadline_column_head($defaults)
 function translation_deadline_column_content($column_name, $post_ID)
 {
     if('translation_deadline' === $column_name) {
-        if('ready' === get_post_meta($post_ID, 'translation_state', true)) {
-            $deadline = get_post_meta($post_ID, 'translation_deadline', true);
-            if ($deadline) {
-                echo date('F j, Y', strtotime($deadline));
-                return;
-            }
+        $deadline = get_post_meta($post_ID, 'translation_deadline', true);
+        if ($deadline) {
+            echo date('F j, Y', strtotime($deadline));
+            return;
         }
+        echo '--';
     }
-}
-
-function sortable_column($columns) {
-    $columns['translation_deadline'] = 'translation_deadline';
-    return $columns;
 }
 
 function translation_deadline_orderby($query) {
     if(!is_admin()) {
         return;
     }
-    
+
     $orderby = $query->get('orderby');
     if('translation_deadline' == $orderby) {
         $query->set('meta_key', 'translation_deadline');
@@ -152,7 +147,6 @@ function translation_deadline_orderby($query) {
 
 add_filter('manage_posts_columns', __NAMESPACE__ . '\translation_deadline_column_head');
 add_action('manage_posts_custom_column', __NAMESPACE__ . '\translation_deadline_column_content', 10, 2);
-add_filter('manage_edit-contenthub_composite_sortable_columns', __NAMESPACE__ . '\sortable_column');
 add_action('pre_get_posts', __NAMESPACE__ . '\translation_deadline_orderby');
 
-add_action('plugins_loaded', __NAMESPACE__ . '\instance', 0);
+add_action('after_setup_theme', __NAMESPACE__ . '\instance', 0);


### PR DESCRIPTION
- Plugin is now compatible with all post types
- Exposes hook to add extra post types not available at instantiation
- The plugin now owns and generates the translation meta box
- Plugin is now generic in the sense that it is no longer dependent on the contenthub editor plugin